### PR TITLE
見た目を改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,58 +2,68 @@
 <html>
   <head>
     <title>Raccoon</title>
-    <link rel="stylesheet" href="http://yui.yahooapis.com/pure/0.6.0/pure-min.css">
-    <link rel="stylesheet" href="node_modules/highlight.js/styles/default.css">
+    <link rel="stylesheet" href="node_modules/highlight.js/styles/monokai_sublime.css">
     <link rel="stylesheet" href="style.css">
-    <meta name="viewport" content="width=device-width,  initial-scale=1">
+    <link href='https://fonts.googleapis.com/css?family=Damion' rel='stylesheet' type='text/css'>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>
-    <div class="pure-g content">
-      <form class="pure-form pure-form-aligned pure-u-1">
+    <div id="container">
+    <div id="alpha">
+      <form>
         <fieldset>
-          <div class="pure-control-group">
+          <div>
             <label for="repo-url">Repository URL</label>
-            <input id="repo-url" type="text" class="pure-input-2-3" placeholder="https://github.com/username/reponame">
+            <input id="repo-url" type="text" placeholder="https://github.com/username/reponame">
           </div>
 
-          <div class="pure-control-group">
+          <div>
             <label for="api-token">Github API Token</label>
-            <input id="api-token" type="password" class="pure-input-2-3" placeholder="your API token">
+            <input id="api-token" type="password" placeholder="your API token">
           </div>
 
-          <div class="pure-control-group">
+          <div>
             <label for="label-name">Label name</label>
-            <input id="label-name" type="text" class="pure-input-2-3" placeholder="label name">
+            <input id="label-name" type="text" placeholder="label name">
           </div>
 
-
-          <div class="pure-controls">
-            <button id="gen-md" class="pure-button pure-button-primary">Generate markdown</button>
+          <div class="controls">
+            <button id="gen-md">Generate markdown</button>
           </div>
         </fieldset>
       </form>
-      <form class="pure-form pure-form-aligned pure-u-1">
+
+      <form class="optional-form">
         <fieldset>
-          <div class="pure-control-group">
+          <div>
             <label for="md-prefix">Prefix</label>
-            <input id="md-prefix" type="text" class="pure-input-2-3" placeholder="prefix" value="-">
+            <input id="md-prefix" type="text" placeholder="prefix" value="-">
           </div>
-          <div class="pure-control-group">
+
+          <div>
             <label for="md-header">Header</label>
-            <textarea id="md-header" class="pure-input-2-3" placeholder="# Header"></textarea>
+            <textarea id="md-header" placeholder="# Header"></textarea>
           </div>
-          <div class="pure-control-group">
+
+          <div>
             <label for="md-footer">Footer</label>
-            <textarea id="md-footer" class="pure-input-2-3" placeholder="# Footer"></textarea>
+            <textarea id="md-footer" placeholder="# Footer"></textarea>
           </div>
         </fieldset>
       </form>
-      <div class="pure-u-1">
-        <pre><code  id="md-area" class="markdown"></code></pre>
+
+      <footer><span class="title">Raccoon</span></footer>
+    </div>
+
+    <div id="beta">
+      <div class="content">
+        <pre><code id="md-area" class="markdown"></code></pre>
       </div>
-      <div class="pure-u-1">
-        <button id="copy-clipboard" class="pure-button pure-button-primary">Copy Clipboard</button>
+
+      <div class="toolbar">
+        <button id="copy-clipboard">Copy to Clipboard</button>
       </div>
+    </div>
     </div>
   </body>
   <script src="index.js"></script>

--- a/style.css
+++ b/style.css
@@ -1,7 +1,160 @@
-div.content {
-  padding: 1em;
-}
 
 #copy-clipboard {
   min-width: 8em;
+}
+
+div#alpha {
+  width: 26em;
+}
+
+body, input, textarea, button {
+  font-family: Avenir, HiraginoSans-W3, "Yu Gothic", sans-serif;
+}
+
+body {
+  margin: 0;
+  background-color: rgb(48, 51, 54);
+  color: white;
+  -webkit-font-smoothing: antialiased;
+  line-height: 1.5;
+  height: 100%;
+  position: relative;
+}
+
+div#beta {
+  width: calc(100% - 26em);
+  background: #292C2F;
+  border-left: 1px solid #0E0F10;
+}
+
+#alpha, #beta {
+  position: relative;
+  box-sizing: border-box;
+}
+
+html {
+  height: 100%;
+}
+
+fieldset {
+  border: none;
+}
+
+form label {
+  min-width: 9em;
+  display: inline-block;
+  font-size: 0.9em;
+}
+
+form input[type="text"],form input[type="password"] {
+  margin-bottom: 1em;
+}
+
+form input, form textarea {
+  background: #292C2F;
+  border: none;
+  color: white;
+}
+
+#alpha form input {
+  width: 19em;
+  padding: 0.5em;
+  font-size: 0.8em;
+  box-sizing: border-box;
+}
+
+div#container {
+  display: flex;
+  min-height: 100%;
+}
+
+footer {
+  text-align: center;
+  height: 3em;
+  padding: 0.3em;
+  border-top: 1px solid #292C2F;
+  box-sizing: border-box;
+}
+
+footer .title {
+  font-size: 1.5em;
+  font-family: Damion;
+}
+
+button#gen-md {
+  border: none;
+  background: #29C46D;
+  padding: 0.5em 1em;
+  font-size: 0.9em;
+  border-radius: 0.3em;
+  color: white;
+  cursor: pointer;
+}
+
+#alpha .controls {
+  text-align: right;
+  padding-right: 1em;
+}
+
+button#gen-md:hover {
+  background: #269E5B;
+}
+
+#beta .toolbar {
+  position: absolute;
+  top: 0;
+  right: 0;
+  background: #43484D;
+}
+
+#beta .toolbar button {
+  background: transparent;
+  border: none;
+  color: white;
+  padding: 1em;
+  cursor: pointer;
+  text-transform: uppercase;
+}
+
+#beta .toolbar button:hover {
+  background: #3A3D40;
+}
+
+textarea, input, button {
+  -webkit-appearance: none;
+}
+
+form.optional-form {
+  padding-top: 1em;   
+  border-top: 1px solid #292C2F;
+}
+
+#alpha form {
+  margin-top: 1em;
+}
+
+#alpha form textarea {
+  display: block;
+  width: calc(100% - 1em);
+  padding: 0.5em;
+  font-size: 0.8em;
+  box-sizing: border-box;
+  margin-top: 0.5em;
+  margin-bottom: 1em;
+  height: 5em;
+}
+
+.optional-form label {
+  color: gray;
+}
+
+#beta .content pre {
+  display: block;
+  margin: 0;
+}
+
+#md-area {
+  display: block;
+  background-color: transparent;
+  padding: 2em;
 }


### PR DESCRIPTION
## 変更点

![2015-12-02 20 28 53](https://cloud.githubusercontent.com/assets/5355966/11529904/7af9cb3e-9933-11e5-90bd-de2625c4e20c.png)
- 内容が長くなるので 2 カラムレイアウトに変更して出力を右側に表示します
- クリップボードへコピーするボタンの位置が内容の長さによって変わらないよう、右上に固定しました
- Prefix 等のラベルを薄くしてオプションっぽくしました
